### PR TITLE
Move environment out of tags to the root

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -92,10 +92,10 @@ class Component extends \yii\base\Component
             return;
         }
 
-        if (is_object($this->client) && property_exists($this->client, 'tags')) {
-            $this->client->tags = ArrayHelper::merge($this->client->tags, ['environment' => $this->environment]);
+        if (is_object($this->client) && property_exists($this->client, 'environment')) {
+            $this->client->environment = $this->environment;
         }
-        $this->jsOptions['tags']['environment'] = $this->environment;
+        $this->jsOptions['environment'] = $this->environment;
     }
 
     private function setRavenClient()

--- a/tests/unit/ComponentTest.php
+++ b/tests/unit/ComponentTest.php
@@ -108,11 +108,10 @@ class ComponentTest extends \yii\codeception\TestCase
         $this->assertEquals($expected, $component->environment);
         $this->assertInstanceOf($clientClass, $component->client);
         if (!empty($environment)) {
-            $this->assertArrayHasKey('tags', $component->jsOptions);
-            $this->assertArrayHasKey('environment', $component->client->tags);
-            $this->assertEquals($expected, $component->client->tags['environment']);
-            $this->assertEquals($expected, $component->jsOptions['tags']['environment']);
-            $this->assertEquals($expected, $component->client->tags['environment']);
+            $this->assertArrayHasKey('environment', $component->jsOptions);
+            $this->assertObjectHasAttribute('environment', $component->client);
+            $this->assertEquals($expected, $component->client->environment);
+            $this->assertEquals($expected, $component->jsOptions['environment']);
         }
     }
 
@@ -159,8 +158,8 @@ class ComponentTest extends \yii\codeception\TestCase
         $this->assertEquals(self::PRIVATE_DSN, $component->client->dsn);
         $this->assertArrayHasKey('test', $component->client->tags);
         $this->assertEquals('value', $component->client->tags['test']);
-        $this->assertArrayHasKey('environment', $component->client->tags);
-        $this->assertEquals(self::ENV_DEVELOPMENT, $component->client->tags['environment']);
+        $this->assertObjectHasAttribute('environment', $component->client);
+        $this->assertEquals(self::ENV_DEVELOPMENT, $component->client->environment);
     }
 
     public function invalidConfigs()

--- a/tests/unit/DummyRavenClient.php
+++ b/tests/unit/DummyRavenClient.php
@@ -5,12 +5,16 @@ namespace mito\sentry\tests\unit;
 class DummyRavenClient
 {
     public $tags = [];
+    public $environment;
     public $dsn;
 
     public function __construct($dsn, $options)
     {
         if (isset($options['tags'])) {
             $this->tags = $options['tags'];
+        }
+        if (isset($options['environment'])) {
+            $this->environment = $options['environment'];
         }
         $this->dsn = $dsn;
     }


### PR DESCRIPTION
raven-js sets the environment in the root configuration array instead of inside the tags. See https://docs.sentry.io/clients/javascript/config/#optional-settings

See #14 