### PR TITLE
Fixes issue with Exception being thrown when no DSN is set

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -61,12 +61,11 @@ class Component extends \yii\base\Component
 
     public function init()
     {
-        $this->validateDsn();
-
         if (!$this->enabled) {
             return;
         }
 
+        $this->validateDsn();
         $this->setRavenClient();
         $this->setEnvironmentOptions();
         $this->generatePublicDsn();


### PR DESCRIPTION
When we have no DSN set in a dev environment, an exception is thrown because no dsn is set.
This PR fixes that when Sentry is disabled.

