### PR TITLE
Don't validate DSN if the Component is disabled

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -61,11 +61,11 @@ class Component extends \yii\base\Component
 
     public function init()
     {
-        $this->validateDsn();
-
         if (!$this->enabled) {
             return;
         }
+
+        $this->validateDsn();
 
         $this->setRavenClient();
         $this->setEnvironmentOptions();


### PR DESCRIPTION
Fixes a crash when the component is disabled and no DSN is provided.

This is useful when setting up the component and target without providing the DSN in the config. I don't want to commit a DSN since I treat it like a password that can be harmful if leaked when a repo goes public (maybe years later), so for my local environments I don't want to provide a DSN. However I do want to configure the component so that it has the same config for all my environments (e.g. ignoring HTTP exceptions).